### PR TITLE
Update CST of PMOD-LED

### DIFF
--- a/pmod_led/src/pmod_led.cst
+++ b/pmod_led/src/pmod_led.cst
@@ -1,72 +1,40 @@
-IO_LOC "pmod_io[0]"  G5;
-IO_LOC "pmod_io[1]"  F5;
-IO_LOC "pmod_io[2]"  G7;
-IO_LOC "pmod_io[3]"  G8;
-IO_LOC "pmod_io[4]"  H7;
-IO_LOC "pmod_io[5]"  H8;
-IO_LOC "pmod_io[6]"  L5;
-IO_LOC "pmod_io[7]"  K5;
-IO_LOC "pmod_io[8]"  J5;
-IO_LOC "pmod_io[9]"  H5;
-IO_LOC "pmod_io[10]" L9;
-IO_LOC "pmod_io[11]" K9;
-IO_LOC "pmod_io[12]" J8;
-IO_LOC "pmod_io[13]" K8;
-IO_LOC "pmod_io[14]" F6;
-IO_LOC "pmod_io[15]" F7;
-IO_LOC "pmod_io[16]" L2;
-IO_LOC "pmod_io[17]" L1;
-IO_LOC "pmod_io[18]" K1;
-IO_LOC "pmod_io[19]" K2;
-IO_LOC "pmod_io[20]" J4;
-IO_LOC "pmod_io[21]" K4;
-IO_LOC "pmod_io[22]" G2;
-IO_LOC "pmod_io[23]" G1;
-IO_LOC "pmod_io[24]" F1;
-IO_LOC "pmod_io[25]" B2;
-IO_LOC "pmod_io[26]" A1;
-IO_LOC "pmod_io[27]" C2;
-IO_LOC "pmod_io[28]" E1;
-IO_LOC "pmod_io[29]" F2;
-IO_LOC "pmod_io[30]" D1;
-IO_LOC "pmod_io[31]" E3;
-IO_LOC "pmod_io[32]" L4;
-IO_LOC "pmod_io[33]" J1;
-IO_LOC "pmod_io[34]" H1;
-IO_LOC "pmod_io[35]" G4;
-IO_LOC "pmod_io[36]" H2;
-IO_LOC "pmod_io[37]" H4;
-IO_LOC "pmod_io[38]" L3;
-IO_LOC "pmod_io[39]" J2;
-IO_LOC "pmod_io[40]" D11;
-IO_LOC "pmod_io[41]" D10;
-IO_LOC "pmod_io[42]" C10;
-IO_LOC "pmod_io[43]" C11;
-IO_LOC "pmod_io[44]" B11;
-IO_LOC "pmod_io[45]" B10;
-IO_LOC "pmod_io[46]" A10;
-IO_LOC "pmod_io[47]" A11;
-IO_LOC "pmod_io[48]" G10;
-IO_LOC "pmod_io[49]" G11;
-IO_LOC "pmod_io[50]" H10;
-IO_LOC "pmod_io[51]" H11;
-IO_LOC "pmod_io[52]" J10;
-IO_LOC "pmod_io[53]" J11;
-IO_LOC "pmod_io[54]" E11;
-IO_LOC "pmod_io[55]" E10;
-IO_LOC "pmod_io[56]" L11;
-IO_LOC "pmod_io[57]" K11;
-IO_LOC "pmod_io[58]" L10;
-IO_LOC "pmod_io[59]" K10;
-IO_LOC "pmod_io[60]" L8;
-IO_LOC "pmod_io[61]" L7;
-IO_LOC "pmod_io[62]" K7;
-IO_LOC "pmod_io[63]" J7;
+// Left Extension Port
+IO_LOC "pmod_io[0]"  J5;
+IO_LOC "pmod_io[1]"  H5;
+IO_LOC "pmod_io[2]"  H7;
+IO_LOC "pmod_io[3]"  H8;
+IO_LOC "pmod_io[4]"  G8;
+IO_LOC "pmod_io[5]"  G7;
+IO_LOC "pmod_io[6]"  G5;
+IO_LOC "pmod_io[7]"  F5;
 
-IO_LOC "led" L6;
+// Center Extension Port
+IO_LOC "pmod_io[8]"  K5;
+IO_LOC "pmod_io[9]"  L5;
+IO_LOC "pmod_io[10]" L11;
+IO_LOC "pmod_io[11]" K11;
+IO_LOC "pmod_io[12]" E10;
+IO_LOC "pmod_io[13]" E11;
+IO_LOC "pmod_io[14]" A10;
+IO_LOC "pmod_io[15]" A11;
+
+// Right Extension Port
+IO_LOC "pmod_io[16]" C10;
+IO_LOC "pmod_io[17]" C11;
+IO_LOC "pmod_io[18]" B10;
+IO_LOC "pmod_io[19]" B11;
+IO_LOC "pmod_io[20]" D10;
+IO_LOC "pmod_io[21]" D11;
+IO_LOC "pmod_io[22]" G10;
+IO_LOC "pmod_io[23]" G11;
+
+
+// Onboard LED's
 IO_LOC "led_done" D7;
 IO_LOC "led_ready" E8;
-IO_LOC "key" K6;
+
+// H11 for S1, H10 for S2
+IO_LOC "key" H11;
 IO_LOC "clk" E2;
 
 IO_PORT "pmod_io[0]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
@@ -77,6 +45,7 @@ IO_PORT "pmod_io[4]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[5]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[6]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[7]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
+
 IO_PORT "pmod_io[8]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[9]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[10]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
@@ -85,6 +54,7 @@ IO_PORT "pmod_io[12]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[13]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[14]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[15]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
+
 IO_PORT "pmod_io[16]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[17]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[18]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
@@ -93,53 +63,10 @@ IO_PORT "pmod_io[20]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[21]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[22]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 IO_PORT "pmod_io[23]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[24]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[25]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[26]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[27]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[28]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[29]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[30]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[31]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[32]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[33]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[34]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[35]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[36]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[37]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[38]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[39]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[40]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[41]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[42]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[43]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[44]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[45]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[46]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[47]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[48]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[49]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[50]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[51]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[52]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[53]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[54]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[55]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[56]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[57]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[58]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[59]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[60]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[61]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[62]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-IO_PORT "pmod_io[63]" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 
-IO_PORT "led" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 
 IO_PORT "led_done" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
-
 IO_PORT "led_ready" PULL_MODE=NONE DRIVE=8 BANK_VCCIO=3.3;
 
-IO_PORT "key" PULL_MODE=NONE DRIVE=OFF BANK_VCCIO=3.3;
-
+IO_PORT "key" PULL_MODE=DOWN DRIVE=OFF BANK_VCCIO=3.3; // Key has a pulldown
 IO_PORT "clk" PULL_MODE=NONE DRIVE=OFF BANK_VCCIO=3.3;

--- a/pmod_led/src/pmod_led.v
+++ b/pmod_led/src/pmod_led.v
@@ -1,6 +1,13 @@
+// Press S1 to see some LED's blinking
+
+// If you get the ERROR PR2017 'x' cannot be placed according to constraint, you need to change some dual used pins to IO
+// Process > Place & Route > Configuration > Dual-Purpose Pins
+// Enable Use READY/DONE/CPU as regular IO
+
+
 module top#(
-    parameter pmod_num = 8, 
-    parameter pmod_io_num = pmod_num * 8 - 1,
+    parameter pmod_num = 3, 
+    parameter pmod_io_num = 3 * 8 - 1,
     parameter frequency = 50_000_000,
     parameter count_ms  = frequency / 1000 ,
     parameter count_us  = count_ms  / 1000 
@@ -35,8 +42,8 @@ always @(posedge clk) begin
 end
 
 genvar pmod_sel;
-generate for ( pmod_sel = 0 ; pmod_sel < 8 ; pmod_sel = pmod_sel + 1)
-        assign pmod_io[ pmod_sel * 8 + 7 : pmod_sel * 8 ] = ~ led_8_state_reg ;
+generate for ( pmod_sel = 0 ; pmod_sel < pmod_num ; pmod_sel = pmod_sel + 1)
+    assign pmod_io[ pmod_sel * 8 + 7 : pmod_sel * 8 ] = ~ led_8_state_reg ;
 endgenerate
 
 assign led = led_output ;


### PR DESCRIPTION
The pmod-led example didn't work out of the box with a TangPrimer-25K, the pin configuration is wrong for the board. More info in the Issue https://github.com/sipeed/TangPrimer-25K-example/issues/11.